### PR TITLE
Translate OpenType language system tags to HTML BCP47 tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,7 @@ dist
 _ignore/
 
 lib/index.js
+
+# External data
+tools/hb-ot-tag-table.hh
+tools/ot-to-html-lang.js

--- a/.gitignore
+++ b/.gitignore
@@ -122,4 +122,3 @@ lib/index.js
 
 # External data
 tools/hb-ot-tag-table.hh
-tools/ot-to-html-lang.js

--- a/src/fondue/Fondue.js
+++ b/src/fondue/Fondue.js
@@ -27,20 +27,13 @@ export default class Fondue {
 	// either GSUB or GPOS. Tags are stripped ("ROM " → "ROM").
 	get languageSystems() {
 		const getLangs = (table) => {
-			let langs = [];
-			if (table) {
-				const scripts = table.getSupportedScripts();
-				for (const script of scripts) {
+			return table
+				.getSupportedScripts()
+				.flatMap((script) => {
 					const scriptTable = table.getScriptTable(script);
-					const LangSyses = table.getSupportedLangSys(scriptTable);
-					if (LangSyses.length) {
-						for (const LangSys of LangSyses) {
-							langs.push(LangSys.trim());
-						}
-					}
-				}
-			}
-			return langs;
+					return table.getSupportedLangSys(scriptTable);
+				})
+				.map((lang) => lang.trim());
 		};
 
 		const gsubLangs = getLangs(this._font.opentype.tables.GSUB);

--- a/src/fondue/Fondue.js
+++ b/src/fondue/Fondue.js
@@ -1,6 +1,7 @@
 import { NAME_TABLE, NAME_RECORD, CMAP_RECORD } from "../tools/variables.js";
 import getCSS, { getCSSAsJSON } from "../tools/css/get-css.js";
 import layoutFeature from "../tools/features/layout-features.js";
+import languages from "../tools/ot-to-html-lang.js";
 import getFormat from "../tools/summary/format.js";
 import getFileSize from "../tools/summary/file-size.js";
 import getFilename from "../tools/summary/filename.js";
@@ -20,6 +21,39 @@ export default class Fondue {
 
 	get isColor() {
 		return this.colorFormats.length >= 1;
+	}
+
+	// Return an object of all language systems supported by
+	// either GSUB or GPOS. Tags are stripped ("ROM " → "ROM").
+	get languageSystems() {
+		const getLangs = (table) => {
+			let langs = [];
+			if (table) {
+				const scripts = table.getSupportedScripts();
+				for (const script of scripts) {
+					const scriptTable = table.getScriptTable(script);
+					const languages = table.getSupportedLangSys(scriptTable);
+					if (languages.length) {
+						for (const language of languages) {
+							langs.push(language.trim());
+						}
+					}
+				}
+			}
+			return langs;
+		};
+
+		const gsubLangs = getLangs(this._font.opentype.tables.GSUB);
+		const gposLangs = getLangs(this._font.opentype.tables.GPOS);
+		const allLangs = new Set([...gsubLangs, ...gposLangs]);
+
+		let langSys = {};
+		for (const lang of allLangs) {
+			if (languages[lang]) {
+				langSys[lang] = languages[lang];
+			}
+		}
+		return langSys;
 	}
 
 	// Gets all information about a table.

--- a/src/fondue/Fondue.js
+++ b/src/fondue/Fondue.js
@@ -29,10 +29,10 @@ export default class Fondue {
 		const getLangs = (table) => {
 			return table
 				.getSupportedScripts()
-				.flatMap((script) => {
+				.reduce((acc, script) => {
 					const scriptTable = table.getScriptTable(script);
-					return table.getSupportedLangSys(scriptTable);
-				})
+					return acc.concat(table.getSupportedLangSys(scriptTable));
+				}, [])
 				.map((lang) => lang.trim());
 		};
 

--- a/src/fondue/Fondue.js
+++ b/src/fondue/Fondue.js
@@ -1,7 +1,7 @@
 import { NAME_TABLE, NAME_RECORD, CMAP_RECORD } from "../tools/variables.js";
 import getCSS, { getCSSAsJSON } from "../tools/css/get-css.js";
 import layoutFeature from "../tools/features/layout-features.js";
-import languages from "../tools/ot-to-html-lang.js";
+import languageMapping from "../tools/ot-to-html-lang.js";
 import getFormat from "../tools/summary/format.js";
 import getFileSize from "../tools/summary/file-size.js";
 import getFilename from "../tools/summary/filename.js";
@@ -32,10 +32,10 @@ export default class Fondue {
 				const scripts = table.getSupportedScripts();
 				for (const script of scripts) {
 					const scriptTable = table.getScriptTable(script);
-					const languages = table.getSupportedLangSys(scriptTable);
-					if (languages.length) {
-						for (const language of languages) {
-							langs.push(language.trim());
+					const LangSyses = table.getSupportedLangSys(scriptTable);
+					if (LangSyses.length) {
+						for (const LangSys of LangSyses) {
+							langs.push(LangSys.trim());
 						}
 					}
 				}
@@ -49,8 +49,8 @@ export default class Fondue {
 
 		let langSys = {};
 		for (const lang of allLangs) {
-			if (languages[lang]) {
-				langSys[lang] = languages[lang];
+			if (languageMapping[lang]) {
+				langSys[lang] = languageMapping[lang];
 			}
 		}
 		return langSys;

--- a/src/tools/ot-to-html-lang.js
+++ b/src/tools/ot-to-html-lang.js
@@ -1,0 +1,2406 @@
+export default {
+	ABA: {
+		html: "abq",
+		name: "Abaza",
+	},
+	ABK: {
+		html: "ab",
+		name: "Abkhazian",
+	},
+	ACH: {
+		html: "ach",
+		name: "Acholi",
+	},
+	ACR: {
+		html: "acr",
+		name: "Achi",
+	},
+	ADY: {
+		html: "ady",
+		name: "Adyghe",
+	},
+	AFK: {
+		html: "af",
+		name: "Afrikaans",
+	},
+	AFR: {
+		html: "aa",
+		name: "Afar",
+	},
+	AGW: {
+		html: "ahg",
+		name: "Agaw",
+	},
+	AIO: {
+		html: "aio",
+		name: "Aiton",
+	},
+	AKA: {
+		html: "tw",
+		name: "Akan",
+	},
+	ALS: {
+		html: "gsw",
+		name: "Alsatian",
+	},
+	ALT: {
+		html: "alt",
+		name: "Southern Altai",
+	},
+	AMH: {
+		html: "am",
+		name: "Amharic",
+	},
+	ANG: {
+		html: "ang",
+		name: "Anglo-Saxon",
+	},
+	APPH: {
+		html: "und-fonnapa",
+		name: "Undetermined; North American Phonetic Alphabet",
+	},
+	ARA: {
+		html: "ar",
+		name: "Arabic",
+	},
+	ARG: {
+		html: "an",
+		name: "Aragonese",
+	},
+	ARI: {
+		html: "aiw",
+		name: "Aari",
+	},
+	ARK: {
+		html: "rki",
+		name: "Rakhine",
+	},
+	ASM: {
+		html: "as",
+		name: "Assamese",
+	},
+	AST: {
+		html: "ast",
+		name: "Asturian",
+	},
+	ATH: {
+		html: "ath",
+		name: "Athapascan",
+	},
+	AVR: {
+		html: "av",
+		name: "Avar",
+	},
+	AWA: {
+		html: "awa",
+		name: "Awadhi",
+	},
+	AYM: {
+		html: "ayr",
+		name: "Aymara",
+	},
+	AZB: {
+		html: "azb",
+		name: "Torki",
+	},
+	AZE: {
+		html: "azj",
+		name: "Azerbaijani",
+	},
+	BAD: {
+		html: "bfq",
+		name: "Badaga",
+	},
+	BAD0: {
+		html: "bad",
+		name: "Banda [family]",
+	},
+	BAG: {
+		html: "ppa",
+		name: "Baghelkhandi",
+	},
+	BAL: {
+		html: "krc",
+		name: "Balkar",
+	},
+	BAN: {
+		html: "ban",
+		name: "Balinese",
+	},
+	BAR: {
+		html: "bar",
+		name: "Bavarian",
+	},
+	BAU: {
+		html: "bci",
+		name: "Baul\u00e9",
+	},
+	BBC: {
+		html: "bbc",
+		name: "Batak Toba",
+	},
+	BBR: {
+		html: "ber",
+		name: "Berber [family]",
+	},
+	BCH: {
+		html: "bcq",
+		name: "Bench",
+	},
+	BDY: {
+		html: "bdy",
+		name: "Bandjalang",
+	},
+	BEL: {
+		html: "be",
+		name: "Belarussian",
+	},
+	BEM: {
+		html: "bem",
+		name: "Bemba (Zambia)",
+	},
+	BEN: {
+		html: "bn",
+		name: "Bengali",
+	},
+	BGC: {
+		html: "bgc",
+		name: "Haryanvi",
+	},
+	BGQ: {
+		html: "bgq",
+		name: "Bagri",
+	},
+	BGR: {
+		html: "bg",
+		name: "Bulgarian",
+	},
+	BHI: {
+		html: "bhi",
+		name: "Bhili",
+	},
+	BHO: {
+		html: "bho",
+		name: "Bhojpuri",
+	},
+	BIK: {
+		html: "bik",
+		name: "Bikol",
+	},
+	BIL: {
+		html: "byn",
+		name: "Bilen",
+	},
+	BIS: {
+		html: "bi",
+		name: "Bislama",
+	},
+	BJJ: {
+		html: "bjj",
+		name: "Kanauji",
+	},
+	BKF: {
+		html: "bla",
+		name: "Blackfoot",
+	},
+	BLI: {
+		html: "bgp",
+		name: "Baluchi",
+	},
+	BLK: {
+		html: "blk",
+		name: "Pa\u2019o Karen",
+	},
+	BLN: {
+		html: "ble",
+		name: "Balante",
+	},
+	BLT: {
+		html: "bft",
+		name: "Balti",
+	},
+	BMB: {
+		html: "bm",
+		name: "Bambara (Bamanankan)",
+	},
+	BML: {
+		html: "bai",
+		name: "Bamileke [family]",
+	},
+	BOS: {
+		html: "bs",
+		name: "Bosnian",
+	},
+	BPY: {
+		html: "bpy",
+		name: "Bishnupriya Manipuri",
+	},
+	BRE: {
+		html: "br",
+		name: "Breton",
+	},
+	BRH: {
+		html: "brh",
+		name: "Brahui",
+	},
+	BRI: {
+		html: "bra",
+		name: "Braj Bhasha",
+	},
+	BRM: {
+		html: "my",
+		name: "Burmese",
+	},
+	BRX: {
+		html: "brx",
+		name: "Bodo (India)",
+	},
+	BSH: {
+		html: "ba",
+		name: "Bashkir",
+	},
+	BSK: {
+		html: "bsk",
+		name: "Burushaski",
+	},
+	BTI: {
+		html: "mct",
+		name: "Beti",
+	},
+	BTS: {
+		html: "bts",
+		name: "Batak Simalungun",
+	},
+	BUG: {
+		html: "bug",
+		name: "Bugis",
+	},
+	BYV: {
+		html: "byv",
+		name: "Medumba",
+	},
+	CAK: {
+		html: "cak",
+		name: "Kaqchikel",
+	},
+	CAT: {
+		html: "ca",
+		name: "Catalan",
+	},
+	CBK: {
+		html: "cbk",
+		name: "Zamboanga Chavacano",
+	},
+	CCHN: {
+		html: "cvn",
+		name: "Chinantec",
+	},
+	CEB: {
+		html: "ceb",
+		name: "Cebuano",
+	},
+	CGG: {
+		html: "cgg",
+		name: "Chiga",
+	},
+	CHA: {
+		html: "ch",
+		name: "Chamorro",
+	},
+	CHE: {
+		html: "ce",
+		name: "Chechen",
+	},
+	CHG: {
+		html: "sgw",
+		name: "Chaha Gurage",
+	},
+	CHH: {
+		html: "hne",
+		name: "Chattisgarhi",
+	},
+	CHI: {
+		html: "ny",
+		name: "Chichewa (Chewa, Nyanja)",
+	},
+	CHK: {
+		html: "ckt",
+		name: "Chukchi",
+	},
+	CHK0: {
+		html: "chk",
+		name: "Chuukese",
+	},
+	CHO: {
+		html: "cho",
+		name: "Choctaw",
+	},
+	CHP: {
+		html: "chp",
+		name: "Chipewyan",
+	},
+	CHR: {
+		html: "chr",
+		name: "Cherokee",
+	},
+	CHU: {
+		html: "cv",
+		name: "Chuvash",
+	},
+	CHY: {
+		html: "chy",
+		name: "Cheyenne",
+	},
+	CJA: {
+		html: "cja",
+		name: "Western Cham",
+	},
+	CJM: {
+		html: "cjm",
+		name: "Eastern Cham",
+	},
+	CMR: {
+		html: "zdj",
+		name: "Comorian",
+	},
+	COP: {
+		html: "cop",
+		name: "Coptic",
+	},
+	COR: {
+		html: "kw",
+		name: "Cornish",
+	},
+	COS: {
+		html: "co",
+		name: "Corsican",
+	},
+	CPP: {
+		html: "crp",
+		name: "Creoles and pidgins",
+	},
+	CRE: {
+		html: "cr",
+		name: "Cree [macrolanguage]",
+	},
+	CRR: {
+		html: "crx",
+		name: "Carrier",
+	},
+	CRT: {
+		html: "crh",
+		name: "Crimean Tatar",
+	},
+	CSB: {
+		html: "csb",
+		name: "Kashubian",
+	},
+	CSL: {
+		html: "cu",
+		name: "Church Slavonic",
+	},
+	CSY: {
+		html: "cs",
+		name: "Czech",
+	},
+	CTG: {
+		html: "ctg",
+		name: "Chittagonian",
+	},
+	CUK: {
+		html: "cuk",
+		name: "San Blas Kuna",
+	},
+	DAN: {
+		html: "da",
+		name: "Danish",
+	},
+	DAR: {
+		html: "dar",
+		name: "Dargwa",
+	},
+	DAX: {
+		html: "dax",
+		name: "Dayi",
+	},
+	DCR: {
+		html: "cwd",
+		name: "Woods Cree",
+	},
+	DEU: {
+		html: "de",
+		name: "German",
+	},
+	DGO: {
+		html: "dgo",
+		name: "Dogri",
+	},
+	DGR: {
+		html: "xnr",
+		name: "Dogri",
+	},
+	DHG: {
+		html: "dhg",
+		name: "Dhangu",
+	},
+	DHV: {
+		html: "dv",
+		name: "Divehi (Dhivehi, Maldivian) (deprecated)",
+	},
+	DIQ: {
+		html: "diq",
+		name: "Dimli",
+	},
+	DIV: {
+		html: "dv",
+		name: "Divehi (Dhivehi, Maldivian)",
+	},
+	DJR: {
+		html: "dje",
+		name: "Zarma",
+	},
+	DJR0: {
+		html: "djr",
+		name: "Djambarrpuyngu",
+	},
+	DNG: {
+		html: "ada",
+		name: "Dangme",
+	},
+	DNJ: {
+		html: "dnj",
+		name: "Dan",
+	},
+	DNK: {
+		html: "din",
+		name: "Dinka",
+	},
+	DRI: {
+		html: "prs",
+		name: "Dari",
+	},
+	DUJ: {
+		html: "dwy",
+		name: "Dhuwal",
+	},
+	DUN: {
+		html: "dng",
+		name: "Dungan",
+	},
+	DZN: {
+		html: "dz",
+		name: "Dzongkha",
+	},
+	EBI: {
+		html: "igb",
+		name: "Ebira",
+	},
+	ECR: {
+		html: "crl",
+		name: "Eastern Cree",
+	},
+	EDO: {
+		html: "bin",
+		name: "Edo",
+	},
+	EFI: {
+		html: "efi",
+		name: "Efik",
+	},
+	ELL: {
+		html: "el",
+		name: "Greek",
+	},
+	EMK: {
+		html: "emk",
+		name: "Eastern Maninkakan",
+	},
+	ENG: {
+		html: "en",
+		name: "English",
+	},
+	ERZ: {
+		html: "myv",
+		name: "Erzya",
+	},
+	ESP: {
+		html: "es",
+		name: "Spanish",
+	},
+	ESU: {
+		html: "esu",
+		name: "Central Yupik",
+	},
+	ETI: {
+		html: "et",
+		name: "Estonian",
+	},
+	EUQ: {
+		html: "eu",
+		name: "Basque",
+	},
+	EVK: {
+		html: "evn",
+		name: "Evenki",
+	},
+	EVN: {
+		html: "eve",
+		name: "Even",
+	},
+	EWE: {
+		html: "ee",
+		name: "Ewe",
+	},
+	FAN: {
+		html: "acf",
+		name: "French Antillean",
+	},
+	FAN0: {
+		html: "fan",
+		name: "Fang (Equatorial Guinea)",
+	},
+	FAR: {
+		html: "pes",
+		name: "Persian",
+	},
+	FAT: {
+		html: "fat",
+		name: "Fanti",
+	},
+	FIN: {
+		html: "fi",
+		name: "Finnish",
+	},
+	FJI: {
+		html: "fj",
+		name: "Fijian",
+	},
+	FLE: {
+		html: "vls",
+		name: "Dutch (Flemish)",
+	},
+	FMP: {
+		html: "fmp",
+		name: "Fe\u2019fe\u2019",
+	},
+	FNE: {
+		html: "yrk",
+		name: "Forest Nenets",
+	},
+	FON: {
+		html: "fon",
+		name: "Fon",
+	},
+	FOS: {
+		html: "fo",
+		name: "Faroese",
+	},
+	FRA: {
+		html: "fr",
+		name: "French",
+	},
+	FRC: {
+		html: "frc",
+		name: "Cajun French",
+	},
+	FRI: {
+		html: "fy",
+		name: "Frisian",
+	},
+	FRL: {
+		html: "fur",
+		name: "Friulian",
+	},
+	FRP: {
+		html: "frp",
+		name: "Arpitan",
+	},
+	FTA: {
+		html: "fuf",
+		name: "Futa",
+	},
+	FUL: {
+		html: "fuq",
+		name: "Fulah",
+	},
+	FUV: {
+		html: "fuv",
+		name: "Nigerian Fulfulde",
+	},
+	GAD: {
+		html: "gaa",
+		name: "Ga",
+	},
+	GAE: {
+		html: "gd",
+		name: "Scottish Gaelic (Gaelic)",
+	},
+	GAG: {
+		html: "gag",
+		name: "Gagauz",
+	},
+	GAL: {
+		html: "gl",
+		name: "Galician",
+	},
+	GAW: {
+		html: "gbm",
+		name: "Garhwali",
+	},
+	GEZ: {
+		html: "gez",
+		name: "Geez",
+	},
+	GIH: {
+		html: "gih",
+		name: "Githabul",
+	},
+	GIL: {
+		html: "niv",
+		name: "Gilyak",
+	},
+	GIL0: {
+		html: "gil",
+		name: "Kiribati (Gilbertese)",
+	},
+	GKP: {
+		html: "gkp",
+		name: "Kpelle (Guinea)",
+	},
+	GLK: {
+		html: "glk",
+		name: "Gilaki",
+	},
+	GMZ: {
+		html: "guk",
+		name: "Gumuz",
+	},
+	GNN: {
+		html: "gnn",
+		name: "Gumatj",
+	},
+	GOG: {
+		html: "gog",
+		name: "Gogo",
+	},
+	GON: {
+		html: "gon",
+		name: "Gondi",
+	},
+	GRN: {
+		html: "kl",
+		name: "Greenlandic",
+	},
+	GRO: {
+		html: "grt",
+		name: "Garo",
+	},
+	GUA: {
+		html: "nhd",
+		name: "Guarani",
+	},
+	GUC: {
+		html: "guc",
+		name: "Wayuu",
+	},
+	GUF: {
+		html: "guf",
+		name: "Gupapuyngu",
+	},
+	GUJ: {
+		html: "gu",
+		name: "Gujarati",
+	},
+	GUK: {
+		html: "guk",
+		name: "Gumuz (SIL fonts)",
+	},
+	GUZ: {
+		html: "guz",
+		name: "Gusii",
+	},
+	HAI: {
+		html: "ht",
+		name: "Haitian (Haitian Creole)",
+	},
+	HAL: {
+		html: "rnl",
+		name: "Halam (Falam Chin)",
+	},
+	HAR: {
+		html: "hoj",
+		name: "Harauti",
+	},
+	HAU: {
+		html: "ha",
+		name: "Hausa",
+	},
+	HAW: {
+		html: "haw",
+		name: "Hawaiian",
+	},
+	HAY: {
+		html: "hay",
+		name: "Haya",
+	},
+	HAZ: {
+		html: "haz",
+		name: "Hazaragi",
+	},
+	HBN: {
+		html: "amf",
+		name: "Hammer-Banna",
+	},
+	HER: {
+		html: "hz",
+		name: "Herero",
+	},
+	HIL: {
+		html: "hil",
+		name: "Hiligaynon",
+	},
+	HIN: {
+		html: "hi",
+		name: "Hindi",
+	},
+	HMA: {
+		html: "mrj",
+		name: "High Mari",
+	},
+	HMN: {
+		html: "hmn",
+		name: "Hmong",
+	},
+	HMO: {
+		html: "ho",
+		name: "Hiri Motu",
+	},
+	HND: {
+		html: "hnd",
+		name: "Southern Hindko",
+	},
+	HO: {
+		html: "hoc",
+		name: "Ho",
+	},
+	HRI: {
+		html: "har",
+		name: "Harari",
+	},
+	HRV: {
+		html: "hr",
+		name: "Croatian",
+	},
+	HUN: {
+		html: "hu",
+		name: "Hungarian",
+	},
+	HYE: {
+		html: "hyw",
+		name: "Armenian",
+	},
+	HYE0: {
+		html: "hy",
+		name: "Armenian East",
+	},
+	IBA: {
+		html: "iba",
+		name: "Iban",
+	},
+	IBB: {
+		html: "ibb",
+		name: "Ibibio",
+	},
+	IBO: {
+		html: "ig",
+		name: "Igbo",
+	},
+	IDO: {
+		html: "io",
+		name: "Ido",
+	},
+	IJO: {
+		html: "ijo",
+		name: "Ijo",
+	},
+	ILE: {
+		html: "ie",
+		name: "Interlingue",
+	},
+	ILO: {
+		html: "ilo",
+		name: "Ilokano",
+	},
+	INA: {
+		html: "ia",
+		name: "Interlingua (International Auxiliary Language Association)",
+	},
+	IND: {
+		html: "in",
+		name: "Indonesian (retired code)",
+	},
+	ING: {
+		html: "inh",
+		name: "Ingush",
+	},
+	INU: {
+		html: "iu",
+		name: "Inuktitut",
+	},
+	IPK: {
+		html: "ik",
+		name: "Inupiaq",
+	},
+	IPPH: {
+		html: "und-fonipa",
+		name: "Undetermined; International Phonetic Alphabet",
+	},
+	IRI: {
+		html: "ga",
+		name: "Irish",
+	},
+	IRT: {
+		html: "ga-Latg",
+		name: "Irish; Latin (Gaelic variant)",
+	},
+	ISL: {
+		html: "is",
+		name: "Icelandic",
+	},
+	ISM: {
+		html: "smn",
+		name: "Inari Sami",
+	},
+	ITA: {
+		html: "it",
+		name: "Italian",
+	},
+	IWR: {
+		html: "iw",
+		name: "Hebrew (retired code)",
+	},
+	JAM: {
+		html: "jam",
+		name: "Jamaican Creole",
+	},
+	JAN: {
+		html: "ja",
+		name: "Japanese",
+	},
+	JAV: {
+		html: "jw",
+		name: "Javanese (retired code)",
+	},
+	JBO: {
+		html: "jbo",
+		name: "Lojban",
+	},
+	JCT: {
+		html: "jct",
+		name: "Krymchak",
+	},
+	JII: {
+		html: "yi",
+		name: "Yiddish",
+	},
+	JUD: {
+		html: "lad",
+		name: "Ladino",
+	},
+	JUL: {
+		html: "dyu",
+		name: "Jula",
+	},
+	KAB: {
+		html: "kbd",
+		name: "Kabardian",
+	},
+	KAB0: {
+		html: "kab",
+		name: "Kabyle",
+	},
+	KAC: {
+		html: "kfr",
+		name: "Kachchi",
+	},
+	KAL: {
+		html: "kln",
+		name: "Kalenjin",
+	},
+	KAN: {
+		html: "kn",
+		name: "Kannada",
+	},
+	KAR: {
+		html: "krc",
+		name: "Karachay",
+	},
+	KAT: {
+		html: "ka",
+		name: "Georgian",
+	},
+	KAZ: {
+		html: "kk",
+		name: "Kazakh",
+	},
+	KDE: {
+		html: "kde",
+		name: "Makonde",
+	},
+	KEA: {
+		html: "kea",
+		name: "Kabuverdianu (Crioulo)",
+	},
+	KEB: {
+		html: "ktb",
+		name: "Kebena",
+	},
+	KEK: {
+		html: "kek",
+		name: "Kekchi",
+	},
+	KGE: {
+		html: "und-Geok",
+		name: "Undetermined; Khutsuri (Asomtavruli and Nuskhuri)",
+	},
+	KHA: {
+		html: "kjh",
+		name: "Khakass",
+	},
+	KHK: {
+		html: "kca",
+		name: "Khanty-Kazim",
+	},
+	KHM: {
+		html: "km",
+		name: "Khmer",
+	},
+	KHN: {
+		html: "kht",
+		name: "Khamti Shan (Microsoft fonts)",
+	},
+	KHS: {
+		html: "kca",
+		name: "Khanty-Shurishkar",
+	},
+	KHT: {
+		html: "kht",
+		name: "Khamti Shan (OpenType spec and SIL fonts)",
+	},
+	KHV: {
+		html: "kca",
+		name: "Khanty-Vakhi",
+	},
+	KHW: {
+		html: "khw",
+		name: "Khowar",
+	},
+	KIK: {
+		html: "ki",
+		name: "Kikuyu (Gikuyu)",
+	},
+	KIR: {
+		html: "ky",
+		name: "Kirghiz (Kyrgyz)",
+	},
+	KIS: {
+		html: "kss",
+		name: "Kisii",
+	},
+	KIU: {
+		html: "kiu",
+		name: "Kirmanjki",
+	},
+	KJD: {
+		html: "kjd",
+		name: "Southern Kiwai",
+	},
+	KJP: {
+		html: "kjp",
+		name: "Eastern Pwo Karen",
+	},
+	KJZ: {
+		html: "kjz",
+		name: "Bumthangkha",
+	},
+	KKN: {
+		html: "kex",
+		name: "Kokni",
+	},
+	KLM: {
+		html: "xal",
+		name: "Kalmyk",
+	},
+	KMB: {
+		html: "kam",
+		name: "Kamba (Kenya)",
+	},
+	KMN: {
+		html: "kfy",
+		name: "Kumaoni",
+	},
+	KMO: {
+		html: "kmw",
+		name: "Komo (Democratic Republic of Congo)",
+	},
+	KMS: {
+		html: "kxc",
+		name: "Komso",
+	},
+	KMZ: {
+		html: "kmz",
+		name: "Khorasani Turkic",
+	},
+	KNR: {
+		html: "kr",
+		name: "Kanuri",
+	},
+	KOD: {
+		html: "kfa",
+		name: "Kodagu",
+	},
+	KOH: {
+		html: "okm",
+		name: "Korean Old Hangul",
+	},
+	KOK: {
+		html: "kok",
+		name: "Konkani",
+	},
+	KOM: {
+		html: "kv",
+		name: "Komi [macrolanguage]",
+	},
+	KON: {
+		html: "ktu",
+		name: "Kikongo",
+	},
+	KON0: {
+		html: "ldi",
+		name: "Kongo",
+	},
+	KOP: {
+		html: "koi",
+		name: "Komi-Permyak",
+	},
+	KOR: {
+		html: "ko",
+		name: "Korean",
+	},
+	KOS: {
+		html: "kos",
+		name: "Kosraean",
+	},
+	KOZ: {
+		html: "kpv",
+		name: "Komi-Zyrian",
+	},
+	KPL: {
+		html: "kpe",
+		name: "Kpelle [macrolanguage]",
+	},
+	KRI: {
+		html: "kri",
+		name: "Krio",
+	},
+	KRK: {
+		html: "kaa",
+		name: "Karakalpak",
+	},
+	KRL: {
+		html: "krl",
+		name: "Karelian",
+	},
+	KRM: {
+		html: "kdr",
+		name: "Karaim",
+	},
+	KRN: {
+		html: "kar",
+		name: "Karen [family]",
+	},
+	KRT: {
+		html: "kqy",
+		name: "Koorete",
+	},
+	KSH: {
+		html: "ks",
+		name: "Kashmiri",
+	},
+	KSH0: {
+		html: "ksh",
+		name: "Ripuarian",
+	},
+	KSI: {
+		html: "kha",
+		name: "Khasi",
+	},
+	KSM: {
+		html: "sjd",
+		name: "Kildin Sami",
+	},
+	KSW: {
+		html: "ksw",
+		name: "S\u2019gaw Karen",
+	},
+	KUA: {
+		html: "kj",
+		name: "Kuanyama",
+	},
+	KUI: {
+		html: "uki",
+		name: "Kui (India)",
+	},
+	KUL: {
+		html: "kfx",
+		name: "Kulvi",
+	},
+	KUM: {
+		html: "kum",
+		name: "Kumyk",
+	},
+	KUR: {
+		html: "ku",
+		name: "Kurdish",
+	},
+	KUU: {
+		html: "kxl",
+		name: "Kurukh",
+	},
+	KUY: {
+		html: "kdt",
+		name: "Kuy",
+	},
+	KYK: {
+		html: "kpy",
+		name: "Koryak",
+	},
+	KYU: {
+		html: "kyu",
+		name: "Western Kayah",
+	},
+	LAD: {
+		html: "lld",
+		name: "Ladin",
+	},
+	LAH: {
+		html: "bfu",
+		name: "Lahuli",
+	},
+	LAK: {
+		html: "lbe",
+		name: "Lak",
+	},
+	LAM: {
+		html: "lmn",
+		name: "Lambani",
+	},
+	LAO: {
+		html: "lo",
+		name: "Lao",
+	},
+	LAT: {
+		html: "la",
+		name: "Latin",
+	},
+	LAZ: {
+		html: "lzz",
+		name: "Laz",
+	},
+	LCR: {
+		html: "crm",
+		name: "L-Cree",
+	},
+	LDK: {
+		html: "lbj",
+		name: "Ladakhi",
+	},
+	LEZ: {
+		html: "lez",
+		name: "Lezgi",
+	},
+	LIJ: {
+		html: "lij",
+		name: "Ligurian",
+	},
+	LIM: {
+		html: "li",
+		name: "Limburgish",
+	},
+	LIN: {
+		html: "ln",
+		name: "Lingala",
+	},
+	LIS: {
+		html: "lis",
+		name: "Lisu",
+	},
+	LJP: {
+		html: "ljp",
+		name: "Lampung",
+	},
+	LKI: {
+		html: "lki",
+		name: "Laki",
+	},
+	LMA: {
+		html: "mhr",
+		name: "Low Mari",
+	},
+	LMB: {
+		html: "lif",
+		name: "Limbu",
+	},
+	LMO: {
+		html: "lmo",
+		name: "Lombard",
+	},
+	LMW: {
+		html: "ngl",
+		name: "Lomwe",
+	},
+	LOM: {
+		html: "lom",
+		name: "Loma (Liberia)",
+	},
+	LRC: {
+		html: "zum",
+		name: "Luri",
+	},
+	LSB: {
+		html: "dsb",
+		name: "Lower Sorbian",
+	},
+	LSM: {
+		html: "smj",
+		name: "Lule Sami",
+	},
+	LTH: {
+		html: "lt",
+		name: "Lithuanian",
+	},
+	LTZ: {
+		html: "lb",
+		name: "Luxembourgish",
+	},
+	LUA: {
+		html: "lua",
+		name: "Luba-Lulua",
+	},
+	LUB: {
+		html: "lu",
+		name: "Luba-Katanga",
+	},
+	LUG: {
+		html: "lg",
+		name: "Ganda",
+	},
+	LUH: {
+		html: "luy",
+		name: "Luyia",
+	},
+	LUO: {
+		html: "luo",
+		name: "Luo (Kenya and Tanzania)",
+	},
+	LVI: {
+		html: "lv",
+		name: "Latvian",
+	},
+	MAD: {
+		html: "mad",
+		name: "Madura",
+	},
+	MAG: {
+		html: "mag",
+		name: "Magahi",
+	},
+	MAH: {
+		html: "mh",
+		name: "Marshallese",
+	},
+	MAJ: {
+		html: "mpe",
+		name: "Majang",
+	},
+	MAK: {
+		html: "vmw",
+		name: "Makhuwa",
+	},
+	MAL: {
+		html: "ml",
+		name: "Malayalam Traditional",
+	},
+	MAM: {
+		html: "mam",
+		name: "Mam",
+	},
+	MAN: {
+		html: "mns",
+		name: "Mansi",
+	},
+	MAP: {
+		html: "arn",
+		name: "Mapudungun",
+	},
+	MAR: {
+		html: "mr",
+		name: "Marathi",
+	},
+	MAW: {
+		html: "mwr",
+		name: "Marwari",
+	},
+	MBN: {
+		html: "kmb",
+		name: "Mbundu",
+	},
+	MBO: {
+		html: "mbo",
+		name: "Mbo (Cameroon)",
+	},
+	MCH: {
+		html: "mnc",
+		name: "Manchu",
+	},
+	MCR: {
+		html: "crm",
+		name: "Moose Cree",
+	},
+	MDE: {
+		html: "men",
+		name: "Mende (Sierra Leone)",
+	},
+	MDR: {
+		html: "mdr",
+		name: "Mandar",
+	},
+	MEN: {
+		html: "mym",
+		name: "Me\u2019en",
+	},
+	MER: {
+		html: "mer",
+		name: "Meru",
+	},
+	MFA: {
+		html: "mfa",
+		name: "Pattani Malay",
+	},
+	MFE: {
+		html: "mfe",
+		name: "Morisyen",
+	},
+	MIN: {
+		html: "min",
+		name: "Minangkabau",
+	},
+	MIZ: {
+		html: "lus",
+		name: "Mizo",
+	},
+	MKD: {
+		html: "mk",
+		name: "Macedonian",
+	},
+	MKR: {
+		html: "mak",
+		name: "Makasar",
+	},
+	MKW: {
+		html: "mkw",
+		name: "Kituba (Congo)",
+	},
+	MLE: {
+		html: "mdy",
+		name: "Male (Ethiopia)",
+	},
+	MLG: {
+		html: "mg",
+		name: "Malagasy",
+	},
+	MLN: {
+		html: "mlq",
+		name: "Malinke",
+	},
+	MLR: {
+		html: "ml",
+		name: "Malayalam Reformed",
+	},
+	MLY: {
+		html: "ms",
+		name: "Malay",
+	},
+	MND: {
+		html: "mnk",
+		name: "Mandinka",
+	},
+	MNG: {
+		html: "mn",
+		name: "Mongolian",
+	},
+	MNI: {
+		html: "mni",
+		name: "Manipuri",
+	},
+	MNK: {
+		html: "myq",
+		name: "Maninka",
+	},
+	MNX: {
+		html: "gv",
+		name: "Manx",
+	},
+	MOH: {
+		html: "moh",
+		name: "Mohawk",
+	},
+	MOK: {
+		html: "mdf",
+		name: "Moksha",
+	},
+	MOL: {
+		html: "ro-MD",
+		name: "Romanian; Moldova",
+	},
+	MON: {
+		html: "mnw",
+		name: "Mon",
+	},
+	MOR: {
+		html: "ary",
+		name: "Moroccan",
+	},
+	MOS: {
+		html: "mos",
+		name: "Mossi",
+	},
+	MRI: {
+		html: "mi",
+		name: "Maori",
+	},
+	MTH: {
+		html: "mai",
+		name: "Maithili",
+	},
+	MTS: {
+		html: "mt",
+		name: "Maltese",
+	},
+	MUN: {
+		html: "unr",
+		name: "Mundari",
+	},
+	MUS: {
+		html: "mus",
+		name: "Muscogee",
+	},
+	MWL: {
+		html: "mwl",
+		name: "Mirandese",
+	},
+	MWW: {
+		html: "mww",
+		name: "Hmong Daw",
+	},
+	MYN: {
+		html: "myn",
+		name: "Mayan [family]",
+	},
+	MZN: {
+		html: "mzn",
+		name: "Mazanderani",
+	},
+	NAG: {
+		html: "nag",
+		name: "Naga-Assamese",
+	},
+	NAH: {
+		html: "nah",
+		name: "Nahuatl [family]",
+	},
+	NAN: {
+		html: "gld",
+		name: "Nanai",
+	},
+	NAP: {
+		html: "nap",
+		name: "Neapolitan",
+	},
+	NAS: {
+		html: "nsk",
+		name: "Naskapi",
+	},
+	NAU: {
+		html: "na",
+		name: "Nauruan",
+	},
+	NAV: {
+		html: "nv",
+		name: "Navajo",
+	},
+	NCR: {
+		html: "csw",
+		name: "N-Cree",
+	},
+	NDB: {
+		html: "nr",
+		name: "Ndebele",
+	},
+	NDC: {
+		html: "ndc",
+		name: "Ndau",
+	},
+	NDG: {
+		html: "ng",
+		name: "Ndonga",
+	},
+	NDS: {
+		html: "nds",
+		name: "Low Saxon",
+	},
+	NEP: {
+		html: "ne",
+		name: "Nepali",
+	},
+	NEW: {
+		html: "new",
+		name: "Newari",
+	},
+	NGA: {
+		html: "nga",
+		name: "Ngbaka",
+	},
+	NHC: {
+		html: "csw",
+		name: "Norway House Cree",
+	},
+	NIS: {
+		html: "njz",
+		name: "Nyishi",
+	},
+	NIU: {
+		html: "niu",
+		name: "Niuean",
+	},
+	NKL: {
+		html: "nyn",
+		name: "Nyankole",
+	},
+	NKO: {
+		html: "nqo",
+		name: "N\u2019Ko",
+	},
+	NLD: {
+		html: "nl",
+		name: "Dutch",
+	},
+	NOE: {
+		html: "noe",
+		name: "Nimadi",
+	},
+	NOG: {
+		html: "nog",
+		name: "Nogai",
+	},
+	NOR: {
+		html: "no",
+		name: "Norwegian",
+	},
+	NOV: {
+		html: "nov",
+		name: "Novial",
+	},
+	NSM: {
+		html: "se",
+		name: "Northern Sami",
+	},
+	NSO: {
+		html: "nso",
+		name: "Sotho, Northern",
+	},
+	NTA: {
+		html: "nod",
+		name: "Northern Tai",
+	},
+	NTO: {
+		html: "eo",
+		name: "Esperanto",
+	},
+	NYM: {
+		html: "nym",
+		name: "Nyamwezi",
+	},
+	NYN: {
+		html: "nn",
+		name: "Norwegian Nynorsk (Nynorsk, Norwegian)",
+	},
+	NZA: {
+		html: "nza",
+		name: "Mbembe Tigon",
+	},
+	OCI: {
+		html: "oc",
+		name: "Occitan (post 1500)",
+	},
+	OCR: {
+		html: "ojs",
+		name: "Oji-Cree",
+	},
+	OJB: {
+		html: "oj",
+		name: "Ojibwa",
+	},
+	ORI: {
+		html: "spv",
+		name: "Odia (formerly Oriya)",
+	},
+	ORO: {
+		html: "om",
+		name: "Oromo",
+	},
+	OSS: {
+		html: "os",
+		name: "Ossetian",
+	},
+	PAA: {
+		html: "sam",
+		name: "Palestinian Aramaic",
+	},
+	PAG: {
+		html: "pag",
+		name: "Pangasinan",
+	},
+	PAL: {
+		html: "pi",
+		name: "Pali",
+	},
+	PAM: {
+		html: "pam",
+		name: "Pampangan",
+	},
+	PAN: {
+		html: "pa",
+		name: "Punjabi",
+	},
+	PAP: {
+		html: "plp",
+		name: "Palpa (retired code)",
+	},
+	PAP0: {
+		html: "pap",
+		name: "Papiamentu",
+	},
+	PAS: {
+		html: "ps",
+		name: "Pashto",
+	},
+	PAU: {
+		html: "pau",
+		name: "Palauan",
+	},
+	PCC: {
+		html: "pcc",
+		name: "Bouyei",
+	},
+	PCD: {
+		html: "pcd",
+		name: "Picard",
+	},
+	PDC: {
+		html: "pdc",
+		name: "Pennsylvania German",
+	},
+	PGR: {
+		html: "el-polyton",
+		name: "Modern Greek (1453-); Polytonic Greek",
+	},
+	PHK: {
+		html: "phk",
+		name: "Phake",
+	},
+	PIH: {
+		html: "pih",
+		name: "Norfolk",
+	},
+	PIL: {
+		html: "fil",
+		name: "Filipino",
+	},
+	PLG: {
+		html: "rbb",
+		name: "Palaung",
+	},
+	PLK: {
+		html: "pl",
+		name: "Polish",
+	},
+	PMS: {
+		html: "pms",
+		name: "Piemontese",
+	},
+	PNB: {
+		html: "pnb",
+		name: "Western Panjabi",
+	},
+	POH: {
+		html: "poh",
+		name: "Pocomchi",
+	},
+	PON: {
+		html: "pon",
+		name: "Pohnpeian",
+	},
+	PRO: {
+		html: "pro",
+		name: "Old Proven\u00e7al (to 1500)",
+	},
+	PTG: {
+		html: "pt",
+		name: "Portuguese",
+	},
+	PWO: {
+		html: "pwo",
+		name: "Western Pwo Karen",
+	},
+	QIN: {
+		html: "zom",
+		name: "Chin",
+	},
+	QUC: {
+		html: "quc",
+		name: "K\u2019iche\u2019",
+	},
+	QUH: {
+		html: "quh",
+		name: "South Bolivian Quechua",
+	},
+	QUZ: {
+		html: "qxu",
+		name: "Quechua",
+	},
+	QVI: {
+		html: "qvi",
+		name: "Imbabura Highland Quichua",
+	},
+	QWH: {
+		html: "qwh",
+		name: "Huaylas Ancash Quechua",
+	},
+	RAJ: {
+		html: "raj",
+		name: "Rajasthani",
+	},
+	RAR: {
+		html: "rar",
+		name: "Rarotongan",
+	},
+	RBU: {
+		html: "bxr",
+		name: "Russian Buriat",
+	},
+	RCR: {
+		html: "atj",
+		name: "R-Cree",
+	},
+	REJ: {
+		html: "rej",
+		name: "Rejang",
+	},
+	RIA: {
+		html: "ria",
+		name: "Riang (India)",
+	},
+	RIF: {
+		html: "rif",
+		name: "Tarifit",
+	},
+	RIT: {
+		html: "rit",
+		name: "Ritarungo",
+	},
+	RKW: {
+		html: "rkw",
+		name: "Arakwal",
+	},
+	RMS: {
+		html: "rm",
+		name: "Romansh",
+	},
+	RMY: {
+		html: "rmy",
+		name: "Vlax Romani",
+	},
+	ROM: {
+		html: "ro",
+		name: "Romanian",
+	},
+	ROY: {
+		html: "rom",
+		name: "Romany",
+	},
+	RSY: {
+		html: "rue",
+		name: "Rusyn",
+	},
+	RTM: {
+		html: "rtm",
+		name: "Rotuman",
+	},
+	RUA: {
+		html: "rw",
+		name: "Kinyarwanda",
+	},
+	RUN: {
+		html: "rn",
+		name: "Rundi",
+	},
+	RUP: {
+		html: "rup",
+		name: "Aromanian",
+	},
+	RUS: {
+		html: "ru",
+		name: "Russian",
+	},
+	SAD: {
+		html: "sck",
+		name: "Sadri",
+	},
+	SAN: {
+		html: "sa",
+		name: "Sanskrit",
+	},
+	SAS: {
+		html: "sas",
+		name: "Sasak",
+	},
+	SAT: {
+		html: "sat",
+		name: "Santali",
+	},
+	SAY: {
+		html: "chp",
+		name: "Sayisi",
+	},
+	SCN: {
+		html: "scn",
+		name: "Sicilian",
+	},
+	SCO: {
+		html: "sco",
+		name: "Scots",
+	},
+	SCS: {
+		html: "scs",
+		name: "North Slavey",
+	},
+	SEK: {
+		html: "xan",
+		name: "Sekota",
+	},
+	SEL: {
+		html: "sel",
+		name: "Selkup",
+	},
+	SGA: {
+		html: "sga",
+		name: "Old Irish (to 900)",
+	},
+	SGO: {
+		html: "sg",
+		name: "Sango",
+	},
+	SGS: {
+		html: "sgs",
+		name: "Samogitian",
+	},
+	SGW: {
+		html: "sgw",
+		name: "Chaha Gurage (SIL fonts)",
+	},
+	SHI: {
+		html: "shi",
+		name: "Tachelhit",
+	},
+	SHN: {
+		html: "shn",
+		name: "Shan",
+	},
+	SIB: {
+		html: "sjo",
+		name: "Sibe",
+	},
+	SID: {
+		html: "sid",
+		name: "Sidamo",
+	},
+	SIG: {
+		html: "xst",
+		name: "Silte Gurage",
+	},
+	SKS: {
+		html: "sms",
+		name: "Skolt Sami",
+	},
+	SKY: {
+		html: "sk",
+		name: "Slovak",
+	},
+	SLA: {
+		html: "xsl",
+		name: "Slavey",
+	},
+	SLV: {
+		html: "sl",
+		name: "Slovenian",
+	},
+	SML: {
+		html: "so",
+		name: "Somali",
+	},
+	SMO: {
+		html: "sm",
+		name: "Samoan",
+	},
+	SNA: {
+		html: "seh",
+		name: "Sena",
+	},
+	SNA0: {
+		html: "sn",
+		name: "Shona",
+	},
+	SND: {
+		html: "sd",
+		name: "Sindhi",
+	},
+	SNH: {
+		html: "si",
+		name: "Sinhala (Sinhalese)",
+	},
+	SNK: {
+		html: "snk",
+		name: "Soninke",
+	},
+	SOG: {
+		html: "gru",
+		name: "Sodo Gurage",
+	},
+	SOP: {
+		html: "sop",
+		name: "Songe",
+	},
+	SOT: {
+		html: "st",
+		name: "Sotho, Southern",
+	},
+	SQI: {
+		html: "sq",
+		name: "Albanian",
+	},
+	SRB: {
+		html: "sr",
+		name: "Serbian",
+	},
+	SRD: {
+		html: "sro",
+		name: "Sardinian",
+	},
+	SRK: {
+		html: "skr",
+		name: "Saraiki",
+	},
+	SRR: {
+		html: "srr",
+		name: "Serer",
+	},
+	SSL: {
+		html: "xsl",
+		name: "South Slavey",
+	},
+	SSM: {
+		html: "sma",
+		name: "Southern Sami",
+	},
+	STQ: {
+		html: "stq",
+		name: "Saterland Frisian",
+	},
+	SUK: {
+		html: "suk",
+		name: "Sukuma",
+	},
+	SUN: {
+		html: "su",
+		name: "Sundanese",
+	},
+	SUR: {
+		html: "suq",
+		name: "Suri",
+	},
+	SVA: {
+		html: "sva",
+		name: "Svan",
+	},
+	SVE: {
+		html: "sv",
+		name: "Swedish",
+	},
+	SWA: {
+		html: "aii",
+		name: "Swadaya Aramaic",
+	},
+	SWK: {
+		html: "swh",
+		name: "Swahili",
+	},
+	SWZ: {
+		html: "ss",
+		name: "Swati",
+	},
+	SXT: {
+		html: "ngo",
+		name: "Sutu",
+	},
+	SXU: {
+		html: "sxu",
+		name: "Upper Saxon",
+	},
+	SYL: {
+		html: "syl",
+		name: "Sylheti",
+	},
+	SYR: {
+		html: "syr",
+		name: "Syriac",
+	},
+	SYRE: {
+		html: "und-Syre",
+		name: "Undetermined; Syriac (Estrangelo variant)",
+	},
+	SYRJ: {
+		html: "und-Syrj",
+		name: "Undetermined; Syriac (Western variant)",
+	},
+	SYRN: {
+		html: "und-Syrn",
+		name: "Undetermined; Syriac (Eastern variant)",
+	},
+	SZL: {
+		html: "szl",
+		name: "Silesian",
+	},
+	TAB: {
+		html: "tab",
+		name: "Tabasaran",
+	},
+	TAJ: {
+		html: "tg",
+		name: "Tajiki",
+	},
+	TAM: {
+		html: "ta",
+		name: "Tamil",
+	},
+	TAT: {
+		html: "tt",
+		name: "Tatar",
+	},
+	TCR: {
+		html: "cwd",
+		name: "TH-Cree",
+	},
+	TDD: {
+		html: "tdd",
+		name: "Dehong Dai",
+	},
+	TEL: {
+		html: "te",
+		name: "Telugu",
+	},
+	TET: {
+		html: "tet",
+		name: "Tetum",
+	},
+	TGL: {
+		html: "tl",
+		name: "Tagalog",
+	},
+	TGN: {
+		html: "to",
+		name: "Tongan",
+	},
+	TGR: {
+		html: "tig",
+		name: "Tigre",
+	},
+	TGY: {
+		html: "ti",
+		name: "Tigrinya",
+	},
+	THA: {
+		html: "th",
+		name: "Thai",
+	},
+	THT: {
+		html: "ty",
+		name: "Tahitian",
+	},
+	TIB: {
+		html: "bo",
+		name: "Tibetan",
+	},
+	TIV: {
+		html: "tiv",
+		name: "Tiv",
+	},
+	TKM: {
+		html: "tk",
+		name: "Turkmen",
+	},
+	TMH: {
+		html: "tmh",
+		name: "Tamashek",
+	},
+	TMN: {
+		html: "tem",
+		name: "Temne",
+	},
+	TNA: {
+		html: "tn",
+		name: "Tswana",
+	},
+	TNE: {
+		html: "yrk",
+		name: "Nenets",
+	},
+	TNG: {
+		html: "toi",
+		name: "Tonga (Zambia)",
+	},
+	TOD: {
+		html: "xwo",
+		name: "Todo",
+	},
+	TOD0: {
+		html: "tod",
+		name: "Toma",
+	},
+	TPI: {
+		html: "tpi",
+		name: "Tok Pisin",
+	},
+	TRK: {
+		html: "tr",
+		name: "Turkish",
+	},
+	TSG: {
+		html: "ts",
+		name: "Tsonga",
+	},
+	TSJ: {
+		html: "tsj",
+		name: "Tshangla",
+	},
+	TUA: {
+		html: "tru",
+		name: "Turoyo Aramaic",
+	},
+	TUL: {
+		html: "tcy",
+		name: "Tumbuka",
+	},
+	TUM: {
+		html: "tum",
+		name: "Tulu",
+	},
+	TUV: {
+		html: "tyv",
+		name: "Tuvin",
+	},
+	TVL: {
+		html: "tvl",
+		name: "Tuvalu",
+	},
+	TWI: {
+		html: "tw",
+		name: "Twi",
+	},
+	TYZ: {
+		html: "tyz",
+		name: "T\u00e0y",
+	},
+	TZM: {
+		html: "tzm",
+		name: "Tamazight",
+	},
+	TZO: {
+		html: "tzo",
+		name: "Tzotzil",
+	},
+	UDM: {
+		html: "udm",
+		name: "Udmurt",
+	},
+	UKR: {
+		html: "uk",
+		name: "Ukrainian",
+	},
+	UMB: {
+		html: "umb",
+		name: "Umbundu",
+	},
+	URD: {
+		html: "ur",
+		name: "Urdu",
+	},
+	USB: {
+		html: "hsb",
+		name: "Upper Sorbian",
+	},
+	UYG: {
+		html: "ug",
+		name: "Uyghur",
+	},
+	UZB: {
+		html: "uzs",
+		name: "Uzbek",
+	},
+	VEC: {
+		html: "vec",
+		name: "Venetian",
+	},
+	VEN: {
+		html: "ve",
+		name: "Venda",
+	},
+	VIT: {
+		html: "vi",
+		name: "Vietnamese",
+	},
+	VOL: {
+		html: "vo",
+		name: "Volap\u00fck",
+	},
+	VRO: {
+		html: "vro",
+		name: "V\u00f5ro",
+	},
+	WA: {
+		html: "wbm",
+		name: "Wa",
+	},
+	WAG: {
+		html: "wbr",
+		name: "Wagdi",
+	},
+	WAR: {
+		html: "war",
+		name: "Waray-Waray",
+	},
+	WCR: {
+		html: "crk",
+		name: "West-Cree",
+	},
+	WEL: {
+		html: "cy",
+		name: "Welsh",
+	},
+	WLF: {
+		html: "wo",
+		name: "Wolof",
+	},
+	WLN: {
+		html: "wa",
+		name: "Walloon",
+	},
+	WTM: {
+		html: "wtm",
+		name: "Mewati",
+	},
+	XBD: {
+		html: "khb",
+		name: "L\u00fc",
+	},
+	XHS: {
+		html: "xh",
+		name: "Xhosa",
+	},
+	XJB: {
+		html: "xjb",
+		name: "Minjangbal",
+	},
+	XKF: {
+		html: "xkf",
+		name: "Khengkha",
+	},
+	XOG: {
+		html: "xog",
+		name: "Soga",
+	},
+	XPE: {
+		html: "xpe",
+		name: "Kpelle (Liberia)",
+	},
+	YAK: {
+		html: "sah",
+		name: "Sakha",
+	},
+	YAO: {
+		html: "yao",
+		name: "Yao",
+	},
+	YAP: {
+		html: "yap",
+		name: "Yapese",
+	},
+	YBA: {
+		html: "yo",
+		name: "Yoruba",
+	},
+	YCR: {
+		html: "cr",
+		name: "Y-Cree",
+	},
+	YIM: {
+		html: "ii",
+		name: "Yi Modern",
+	},
+	ZEA: {
+		html: "zea",
+		name: "Zealandic",
+	},
+	ZGH: {
+		html: "zgh",
+		name: "Standard Moroccan Tamazight",
+	},
+	ZHA: {
+		html: "zzj",
+		name: "Zhuang",
+	},
+	ZHH: {
+		html: "zh-HK",
+		name: "Chinese; Hong Kong",
+	},
+	ZHS: {
+		html: "zh-Hans",
+		name: "Chinese; Han (Simplified variant)",
+	},
+	ZHT: {
+		html: "zh-Hant",
+		name: "Chinese; Han (Traditional variant)",
+	},
+	ZND: {
+		html: "zne",
+		name: "Zande",
+	},
+	ZUL: {
+		html: "zu",
+		name: "Zulu",
+	},
+	ZZA: {
+		html: "zza",
+		name: "Zazaki [macrolanguage]",
+	},
+};

--- a/test/Fondue.test.js
+++ b/test/Fondue.test.js
@@ -158,3 +158,14 @@ describe("supportedCharacters", () => {
 		);
 	});
 });
+
+describe("supportedLanguages", () => {
+	test("returns supported languages", async () => {
+		const fondue = await variableFont();
+		expect(fondue.languageSystems).toEqual(
+			expect.objectContaining({
+				ATH: { html: "ath", name: "Athapascan" },
+			})
+		);
+	});
+});

--- a/tools/lang-tags-from-hb.py
+++ b/tools/lang-tags-from-hb.py
@@ -16,12 +16,12 @@ import sys
 import json
 
 
-def extractLanguages(content):
+def extract_languages(content):
     langdict = {}
 
     # Regular languages
-    langContent = content.split("ot_languages[] = {\n")[1].split("\n};")[0]
-    languages = langContent.split("\n")
+    lang_content = content.split("ot_languages[] = {\n")[1].split("\n};")[0]
+    languages = lang_content.split("\n")
 
     # This loop will encounter some languages more than once,
     # e.g. "ATH " or "TNE " and will overwrite them!
@@ -46,39 +46,39 @@ def extractLanguages(content):
         # Human readable name
         tmp = parts[1].split("->")
         if len(tmp) == 2:
-            langName = tmp[1].strip()
+            lang_name = tmp[1].strip()
         else:
-            langName = tmp[0].strip()
+            lang_name = tmp[0].strip()
 
         # BCP47 and OT tag
         tmp = parts[0].split(",")
-        langBCP = tmp[0].strip()
-        langOT = tmp[1].strip()
+        lang_bcp = tmp[0].strip()
+        lang_ot = tmp[1].strip()
 
-        langdict[langOT] = {"html": langBCP, "name": langName}
+        langdict[lang_ot] = {"html": lang_bcp, "name": lang_name}
 
     # Ambiguous languages
-    amLangContent = (
+    am_lang_content = (
         content.split("hb_ot_ambiguous_tag_to_language (hb_tag_t tag)")[1]
         .split("{\n")[2]
         .split("default")[0]
     )
-    amLanguages = amLangContent.replace("\n    ", "").split("\n")
+    am_languages = am_lang_content.replace("\n    ", "").split("\n")
 
     # This loop will replace ambiguous languages with the
     # "correct" ones, as deemed by the HarfBuzz project
-    for amLanguage in amLanguages:
-        if amLanguage.strip():
+    for am_language in am_languages:
+        if am_language.strip():
             # Clean up some noise
-            amLanguage = (
-                amLanguage.replace("case HB_TAG('", "").replace("','", "").strip()
+            am_language = (
+                am_language.replace("case HB_TAG('", "").replace("','", "").strip()
             )
 
-            amLangOT = amLanguage.split("'")[0].strip().strip()
-            amLangBCP = amLanguage.split('("')[1].split('"')[0].strip()
-            amLangName = amLanguage.split(";  /*")[1].split("*/")[0].strip()
+            am_lang_ot = am_language.split("'")[0].strip().strip()
+            am_lang_bcp = am_language.split('("')[1].split('"')[0].strip()
+            am_lang_name = am_language.split(";  /*")[1].split("*/")[0].strip()
 
-            langdict[amLangOT] = {"html": amLangBCP, "name": amLangName}
+            langdict[am_lang_ot] = {"html": am_lang_bcp, "name": am_lang_name}
 
     return langdict
 
@@ -88,13 +88,13 @@ def main():
         with open(sys.argv[1]) as f:
             content = f.read()
 
-        languages = extractLanguages(content)
+        languages = extract_languages(content)
         languages = json.dumps(languages, indent=4, sort_keys=True)
 
-        languagesJS = "export default " + languages + ";"
+        languages_js = "export default " + languages + ";"
 
         with open("ot-to-html-lang.js", "w") as out:
-            out.write(languagesJS + "\n")
+            out.write(languages_js + "\n")
 
 
 if __name__ == "__main__":

--- a/tools/lang-tags-from-hb.py
+++ b/tools/lang-tags-from-hb.py
@@ -2,7 +2,7 @@
 #
 # Author: Roel Nieskens (roel@pixelambacht.nl)
 #
-# Usage: ./lang-tags-from-hb.py hb-ot-tag-table.hh
+# Usage: ./lang-tags-from-hb.py hb-ot-tag-table.hh > ../src/tools/ot-to-html-lang.js
 #
 # File should be formatted as in this version:
 # https://github.com/harfbuzz/harfbuzz/blob/7a961692e9568806221de8b2e2bf41bdfc1b8b3f/src/hb-ot-tag-table.hh
@@ -95,8 +95,7 @@ def main():
 
         languages_js = "export default " + languages + ";"
 
-        with open("ot-to-html-lang.js", "w") as out:
-            out.write(languages_js + "\n")
+        print(languages_js)
 
 
 if __name__ == "__main__":

--- a/tools/lang-tags-from-hb.py
+++ b/tools/lang-tags-from-hb.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+#
+# Author: Roel Nieskens (roel@pixelambacht.nl)
+#
+# Usage: ./lang-tags-from-hb.py hb-ot-tag-table.hh
+#
+# Get the table from HarfBuzz:
+# https://raw.githubusercontent.com/harfbuzz/harfbuzz/master/src/hb-ot-tag-table.hh
+#
+# The generated ot-to-html-lang.js file is used by
+# Wakamai Fondue to map OpenType LangSys tags to their
+# corresponding BCP 47 value, to be used in the `lang`
+# attribute.
+
+import sys
+import json
+
+
+def extractLanguages(content):
+    langdict = {}
+
+    # Regular languages
+    langContent = content.split("ot_languages[] = {\n")[1].split("\n};")[0]
+    languages = langContent.split("\n")
+
+    # This loop will encounter some languages more than once,
+    # e.g. "ATH " or "TNE " and will overwrite them!
+    # This will be fixed by the "ambiguous languages"
+    # further on
+    for language in languages:
+        # Clean up some noise
+        language = (
+            language.replace("HB_TAG(", "")
+            .replace("','", "")
+            .replace("},", "")
+            .replace("{", "")
+            .replace("/*", "")
+            .replace("*/", "")
+            .replace("'", "")
+            .replace('"', "")
+            .strip()
+        )
+
+        parts = language.split(")", 1)
+
+        # Human readable name
+        tmp = parts[1].split("->")
+        if len(tmp) == 2:
+            langName = tmp[1].strip()
+        else:
+            langName = tmp[0].strip()
+
+        # BCP47 and OT tag
+        tmp = parts[0].split(",")
+        langBCP = tmp[0].strip()
+        langOT = tmp[1].strip()
+
+        langdict[langOT] = {"html": langBCP, "name": langName}
+
+    # Ambiguous languages
+    amLangContent = (
+        content.split("hb_ot_ambiguous_tag_to_language (hb_tag_t tag)")[1]
+        .split("{\n")[2]
+        .split("default")[0]
+    )
+    amLanguages = amLangContent.replace("\n    ", "").split("\n")
+
+    # This loop will replace ambiguous languages with the
+    # "correct" ones, as deemed by the HarfBuzz project
+    for amLanguage in amLanguages:
+        if amLanguage.strip():
+            # Clean up some noise
+            amLanguage = (
+                amLanguage.replace("case HB_TAG('", "").replace("','", "").strip()
+            )
+
+            amLangOT = amLanguage.split("'")[0].strip().strip()
+            amLangBCP = amLanguage.split('("')[1].split('"')[0].strip()
+            amLangName = amLanguage.split(";  /*")[1].split("*/")[0].strip()
+
+            langdict[amLangOT] = {"html": amLangBCP, "name": amLangName}
+
+    return langdict
+
+
+def main():
+    if len(sys.argv) > 1:
+        with open(sys.argv[1]) as f:
+            content = f.read()
+
+        languages = extractLanguages(content)
+        languages = json.dumps(languages, indent=4, sort_keys=True)
+
+        languagesJS = "export const LANGUAGES = " + languages + ";"
+
+        with open("ot-to-html-lang.js", "a") as out:
+            out.write(languagesJS + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/lang-tags-from-hb.py
+++ b/tools/lang-tags-from-hb.py
@@ -4,7 +4,9 @@
 #
 # Usage: ./lang-tags-from-hb.py hb-ot-tag-table.hh
 #
-# Get the table from HarfBuzz:
+# File should be formatted as in this version:
+# https://github.com/harfbuzz/harfbuzz/blob/7a961692e9568806221de8b2e2bf41bdfc1b8b3f/src/hb-ot-tag-table.hh
+# Get the latest table from HarfBuzz:
 # https://raw.githubusercontent.com/harfbuzz/harfbuzz/master/src/hb-ot-tag-table.hh
 #
 # The generated ot-to-html-lang.js file is used by

--- a/tools/lang-tags-from-hb.py
+++ b/tools/lang-tags-from-hb.py
@@ -91,9 +91,9 @@ def main():
         languages = extractLanguages(content)
         languages = json.dumps(languages, indent=4, sort_keys=True)
 
-        languagesJS = "export const LANGUAGES = " + languages + ";"
+        languagesJS = "export default " + languages + ";"
 
-        with open("ot-to-html-lang.js", "a") as out:
+        with open("ot-to-html-lang.js", "w") as out:
             out.write(languagesJS + "\n")
 
 


### PR DESCRIPTION
We're depending on HarfBuzz, who keep an [extensive list](https://raw.githubusercontent.com/harfbuzz/harfbuzz/master/src/hb-ot-tag-table.hh) of these translations. We take that file, translate it from C++ code to a JavaScript file exporting a JSON list. This is then used by the engine to map a font's LangSys tags in either GSUB or GPOS to their matching BCP 47 tags, so we can use these for the HTML `lang` attribute in the type tester.