### PR TITLE
Rename package to @wakamai-fondue/engine

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-	"name": "fondue",
+	"name": "@wakamai-fondue/engine",
 	"version": "1.0.0",
 	"lockfileVersion": 1,
 	"requires": true,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "fondue",
+	"name": "@wakamai-fondue/engine",
 	"version": "1.0.0",
 	"description": "What if you could actually inspect your web fonts? In the same context that you actually use those web fonts? That's what this is for.",
 	"module": "./index.js",


### PR DESCRIPTION
`fondue` is alraedy taken on NPM. We might not publish the engine itself on
NPM, but this did cause NPM to list the unrelated `fondue` module as a
dependency.