### PR TITLE
Return CPAL color palettes

### DIFF
--- a/src/fondue/Fondue.js
+++ b/src/fondue/Fondue.js
@@ -278,16 +278,16 @@ export default class Fondue {
 	}
 
 	get colorPalettes() {
-		let palettes = [];
+		const cpal = this._font.opentype.tables.CPAL;
+		if (!cpal) return [];
 
 		// Create padded hex value for color string
 		const hex = (d) => Number(d).toString(16).padStart(2, "0");
 
 		// Convert color records to RGBA hex strings
 		// and group them per palette
-		const cpal = this._font.opentype.tables.CPAL;
 		if (cpal) {
-			palettes = cpal.colorRecords.reduce((colors, clr, index) => {
+			return cpal.colorRecords.reduce((colors, clr, index) => {
 				const groupIndex = Math.floor(index / cpal.numPaletteEntries);
 
 				if (!colors[groupIndex]) {
@@ -304,8 +304,6 @@ export default class Fondue {
 				return colors;
 			}, []);
 		}
-
-		return palettes;
 	}
 
 	// Gets all information about the font summary.

--- a/src/fondue/Fondue.js
+++ b/src/fondue/Fondue.js
@@ -284,8 +284,10 @@ export default class Fondue {
 		// Create padded hex value for color string
 		const hex = (d) => Number(d).toString(16).padStart(2, "0");
 
-		// Convert color records to RGBA hex strings
-		// and group them per palette
+		// CPAL's colorRecords is one large, flat array of colors.
+		// We need to chop these up depending on numPaletteEntries
+		// (the number of colors per palette) so we can return an
+		// array of color-arrays.
 		return cpal.colorRecords.reduce((colors, clr, index) => {
 			const groupIndex = Math.floor(index / cpal.numPaletteEntries);
 

--- a/src/fondue/Fondue.js
+++ b/src/fondue/Fondue.js
@@ -277,6 +277,29 @@ export default class Fondue {
 		return tables.filter((table) => colorTables.includes(table));
 	}
 
+	get colorPalettes() {
+		let palettes = [];
+
+		// Create padded hex value for color string
+		const hex = (d) => Number(d).toString(16).padStart(2, "0");
+
+		// Convert color records to RGBA hex strings
+		// TODO: how are multiple palettes handled???
+		const cpal = this._font.opentype.tables.CPAL;
+		if (cpal) {
+			cpal.colorRecords.map((clr) => {
+				palettes.push(
+					`#${hex(clr.red)}` +
+						`${hex(clr.green)}` +
+						`${hex(clr.blue)}` +
+						`${hex(clr.alpha)}`
+				);
+			});
+		}
+
+		return palettes;
+	}
+
 	// Gets all information about the font summary.
 	// Usage:
 	//   fondue.summary

--- a/src/fondue/Fondue.js
+++ b/src/fondue/Fondue.js
@@ -286,24 +286,22 @@ export default class Fondue {
 
 		// Convert color records to RGBA hex strings
 		// and group them per palette
-		if (cpal) {
-			return cpal.colorRecords.reduce((colors, clr, index) => {
-				const groupIndex = Math.floor(index / cpal.numPaletteEntries);
+		return cpal.colorRecords.reduce((colors, clr, index) => {
+			const groupIndex = Math.floor(index / cpal.numPaletteEntries);
 
-				if (!colors[groupIndex]) {
-					colors[groupIndex] = [];
-				}
+			if (!colors[groupIndex]) {
+				colors[groupIndex] = [];
+			}
 
-				colors[groupIndex].push(
-					`#${hex(clr.red)}` +
-						`${hex(clr.green)}` +
-						`${hex(clr.blue)}` +
-						`${hex(clr.alpha)}`
-				);
+			colors[groupIndex].push(
+				`#${hex(clr.red)}` +
+					`${hex(clr.green)}` +
+					`${hex(clr.blue)}` +
+					`${hex(clr.alpha)}`
+			);
 
-				return colors;
-			}, []);
-		}
+			return colors;
+		}, []);
 	}
 
 	// Gets all information about the font summary.

--- a/src/fondue/Fondue.js
+++ b/src/fondue/Fondue.js
@@ -284,17 +284,25 @@ export default class Fondue {
 		const hex = (d) => Number(d).toString(16).padStart(2, "0");
 
 		// Convert color records to RGBA hex strings
-		// TODO: how are multiple palettes handled???
+		// and group them per palette
 		const cpal = this._font.opentype.tables.CPAL;
 		if (cpal) {
-			cpal.colorRecords.map((clr) => {
-				palettes.push(
+			palettes = cpal.colorRecords.reduce((colors, clr, index) => {
+				const groupIndex = Math.floor(index / cpal.numPaletteEntries);
+
+				if (!colors[groupIndex]) {
+					colors[groupIndex] = [];
+				}
+
+				colors[groupIndex].push(
 					`#${hex(clr.red)}` +
 						`${hex(clr.green)}` +
 						`${hex(clr.blue)}` +
 						`${hex(clr.alpha)}`
 				);
-			});
+
+				return colors;
+			}, []);
 		}
 
 		return palettes;

--- a/test/Fondue.test.js
+++ b/test/Fondue.test.js
@@ -116,6 +116,29 @@ describe("hasColorTable", () => {
 	});
 });
 
+describe("hasColorPaletteTable", () => {
+	test("CPAL entries", async () => {
+		const fondue = await colorFont();
+		expect(fondue.colorPalettes).toEqual([
+			[
+				"#34343fff",
+				"#fcc200ff",
+				"#e541414d",
+				"#ffffffff",
+				"#9f4f00ff",
+				"#592700ff",
+				"#e54141ff",
+				"#69b2ccff",
+			],
+		]);
+	});
+
+	test("non color font", async () => {
+		const fondue = await WFTestFont();
+		expect(fondue.colorPalettes).toStrictEqual([]);
+	});
+});
+
 describe("hasAxes", () => {
 	test("variable font axes", async () => {
 		const fondue = await variableFont();


### PR DESCRIPTION
Note: colorRecords contains one single array. Our test font has
just one CPAL palette, so this is fine. What happens when
multiple palettes are in the font?

(Assumption: colors are listed in one big array and you have to
"cut" them into the separate palettes based on the number of
colors per palette)