### PR TITLE
Exclude @font-face from generated CSS

### DIFF
--- a/src/fondue/Fondue.js
+++ b/src/fondue/Fondue.js
@@ -426,6 +426,11 @@ export default class Fondue {
 		return getCSS(this);
 	}
 
+	// Get CSS as string, but with the option to exclude parts
+	fontCSS(exclude) {
+		return getCSS(this, exclude);
+	}
+
 	// Returns whether a specific character is supported by this font.
 	// Example:
 	//   fondue.supports('A') -> returns whether the character 'A' is supported by this font.

--- a/src/tools/css/get-css.js
+++ b/src/tools/css/get-css.js
@@ -155,7 +155,7 @@ const getFontFace = (font) => {
 	return fontface;
 };
 
-const getCSS = (fondue) => {
+const getCSS = (fondue, ...exclude) => {
 	// Skip features for now
 	const features = getAvailableFeatures(fondue);
 	// Make a 'slug' of the font name to use throughout CSS
@@ -171,7 +171,10 @@ const getCSS = (fondue) => {
 		" */\n\n";
 
 	stylesheet = stylesheet + stylesheetIntro;
-	stylesheet = stylesheet + getFontFace(fondue);
+
+	if (!exclude.includes("font-face")) {
+		stylesheet = stylesheet + getFontFace(fondue);
+	}
 
 	if (features.length) {
 		// Layout stuff


### PR DESCRIPTION
This is needed for Google Fonts. I only implemented this specifically
for @font-face, but this should be expanded to enable further
fine-tuning of the CSS (exclude Unicode range, variable stuff,
layout features stuff, etc.).

Also, tests should be added, and optionally the `cssString` gettter
should be deprecated.