### PR TITLE
Update Node version range in CI, use modern Node version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,6 @@ name: CI
 
 on:
   push:
-    branches:
-      - master
   pull_request:
     branches:
       - master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,6 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm
-      - run: npm install
+      - run: npm ci
       - run: npm run lint
       - run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,6 @@ name: CI
 
 on:
   push:
-  pull_request:
-    branches:
-      - master
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,14 +14,15 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [18, 20, 22]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
+          cache: npm
       - run: npm install
       - run: npm run lint
       - run: npm test

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-nodejs 15.4.0
+nodejs 22.9.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1650,7 +1650,6 @@
 				"jest-resolve": "^26.6.2",
 				"jest-util": "^26.6.2",
 				"jest-worker": "^26.6.2",
-				"node-notifier": "^8.0.0",
 				"slash": "^3.0.0",
 				"source-map": "^0.6.0",
 				"string-length": "^4.0.1",
@@ -3546,8 +3545,7 @@
 				"esprima": "^4.0.1",
 				"estraverse": "^5.2.0",
 				"esutils": "^2.0.2",
-				"optionator": "^0.8.1",
-				"source-map": "~0.6.1"
+				"optionator": "^0.8.1"
 			},
 			"bin": {
 				"escodegen": "bin/escodegen.js",
@@ -5896,7 +5894,6 @@
 				"@types/node": "*",
 				"anymatch": "^3.0.3",
 				"fb-watchman": "^2.0.0",
-				"fsevents": "^2.1.2",
 				"graceful-fs": "^4.2.4",
 				"jest-regex-util": "^26.0.0",
 				"jest-serializer": "^26.6.2",
@@ -8628,9 +8625,6 @@
 			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.35.1.tgz",
 			"integrity": "sha512-q5KxEyWpprAIcainhVy6HfRttD9kutQpHbeqDTWnqAFNJotiojetK6uqmcydNMymBEtC4I8bCYR+J3mTMqeaUA==",
 			"dev": true,
-			"dependencies": {
-				"fsevents": "~2.1.2"
-			},
 			"bin": {
 				"rollup": "dist/bin/rollup"
 			},

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
 		}
 	},
 	"engines": {
-		"node": ">=12"
+		"node": ">=18"
 	},
 	"dependencies": {
 		"lib-font": "^2.4.2"


### PR DESCRIPTION
Closes #42.

Hello! I saw the post on Mastodon and the organizing issue and decided to try and help if I can! I did a few things here, mostly with the goal of establishing a solid foundation for testing future changes against modern versions of Node.

- Happy to undo this, but I've made the CI action run against _every_ commit instead of just `master` and PRs against `master`. I think this will put the matrix testing to better use (and because PRs are made of commits, those will still get tested!)
- I've bumped the matrix up to `v18`, `v20` and `v22`. `v20` is the current LTS version, but it [goes into maintenance mode in 15 days](https://github.com/nodejs/release#release-schedule) and `v22` will take its place.
- I've updated the action versions, and now `actions/setup-node@v4` will use caching to speed up installs.
- I've bumped the working version of Node to `v22` in the project. Could see an argument for using `v20` instead, but did so for the same reason as above!
- The `package-lock.json` appeared to be out of sync because every install would update it locally. I updated the CI command to use `npm ci` instead of `npm install` which would catch this mismatch. Definitely some dependencies that could stand to be updated, but all tests _are_ passing, which is nice.

If any/all of this doesn't feel like it makes sense, just let me know! (Or feel free to close it if I'm way off base.)